### PR TITLE
Fix bug with invalid directive.

### DIFF
--- a/compiler/syntax-kinds.def
+++ b/compiler/syntax-kinds.def
@@ -13,6 +13,7 @@ Tk(UnDefDirectiveKw);
 Tk(LineDirectiveKw);
 Tk(ErrorDirectiveKw);
 Tk(WarningDirectiveKw);
+Tk(InvalidDirective);
 
 Tk(LParenSymbol);      Tk(RParenSymbol);
 Tk(LBracketSymbol);    Tk(RBracketSymbol);

--- a/compiler/syntax.cc
+++ b/compiler/syntax.cc
@@ -5,6 +5,7 @@
     className::~className() {}                            \
     void className::Accept(SyntaxTokenVisitor& visitor) { \
         visitor.Visit(*this);                             \
-    }
+    } \
+    class className
 #include "syntax-kinds.def"
 #undef Tk


### PR DESCRIPTION
If an invalid directive is given, i.e.

`#xxx`

It previously causes a crash. This is fixed by adding another token type
in lexer for parsing "invalid directives"